### PR TITLE
Rename column named to Internal Employee

### DIFF
--- a/src/components/Profile/List/index.jsx
+++ b/src/components/Profile/List/index.jsx
@@ -109,9 +109,9 @@ const ListProfiles = () => {
         }
       },
       onCancel: () => {},
-      message: `Are you sure you want to ${
-        checked ? "active" : "inactive"
-      } this employee?`,
+      message: `Are you sure you want to mark this profile as an ${
+        checked ? "Internal Employee" : "External Candidate"
+      }?`,
     });
   };
 
@@ -347,7 +347,7 @@ const ListProfiles = () => {
       render: (date) => formatDate(date),
     },
     {
-      title: "Active Status",
+      title: "Internal Employee",
       dataIndex: "is_josh_employee",
       key: "is_josh_employee",
       render: (_, record) => (


### PR DESCRIPTION
- change the column name "Active Status" to "Internal Employee" 
- improved Confirmation Message Clarity
- "Are you sure you want to mark this profile as an Internal Employee?" (when toggling ON)
- "Are you sure you want to mark this profile as an External Candidate?" (when toggling OFF)